### PR TITLE
fix bug in cppTAfact. Eigen:Dynamic==-1 and is int, not unsigned int

### DIFF
--- a/src/cppTAfact.cpp
+++ b/src/cppTAfact.cpp
@@ -746,7 +746,7 @@ RcppExport SEXP cppTAfact(SEXP mDtSEXP, SEXP mTtinitSEXP, SEXP mAinitSEXP,
     RMatrixIn mAinit(as<RMatrixIn>(mAinitSEXP));
 
     /* Dimensionality of a problem */
-    const size_t d = mAinit.rows() > 16 ? Dynamic : mAinit.rows();
+    const int d = mAinit.rows() > 16 ? Dynamic : mAinit.rows();
 
     RMatrixOut mTtout, mAout;
     SolverSuppOutput supp;


### PR DESCRIPTION
The line with the dimensionality check is wrong because it uses `size_t` instead of `int`.
I am quite surprised it did not segfault earlier...