### PR TITLE
Added a line about Mac compilation errors to the vignettes

### DIFF
--- a/vignettes/MeDeCom.Rmd
+++ b/vignettes/MeDeCom.Rmd
@@ -49,6 +49,7 @@ devtools::install_github("lutsik/MeDeCom")
 ```
 
 The master branch of the GitHub repository only compiles on *nix-like* platforms with a C++11-compatible compiler are supported.
+Users on Mac OS might run into compilation errors as OpenMP, which is required for compilation, is disabled by default. To enable OpenMP, the following tutorial can be followed [https://mac.r-project.org/openmp/](https://mac.r-project.org/openmp/)
 We created a separate branch for installation of *MeDeCom* on Windows machines. However, parallel processing options are currently
 not supported for Windows due to some incompatabilites of the R/Windows connection. Thus, executing MeDeCom on a Windows machine
 takes sustantially longer. Additionally, we creared a Docker image with MeDeCom, which can be used in case of further installation

--- a/vignettes/MeDeCom.html
+++ b/vignettes/MeDeCom.html
@@ -536,8 +536,8 @@ LMCs <em>MeDeCom</em> uses a special for of regularization controlled by the par
 <h1>Installation</h1>
 <p><em>MeDeCom</em> can be installed directly from github using the package <code>devtools</code>:</p>
 <pre class="r"><code class="hljs">devtools::install_github(<span class="hljs-string">"lutsik/MeDeCom"</span>)</code></pre>
-<p>The master branch of the GitHub repository only compiles on <em>nix-like</em> platforms with a C++11-compatible compiler are supported. We created a separate branch for installation of <em>MeDeCom</em>
- on Windows machines. However, parallel processing options are currently
+<p>The master branch of the GitHub repository only compiles on <em>nix-like</em> platforms with a C++11-compatible compiler are supported. Users on Mac OS might run into compilation errors as OpenMP, which is required for compilation, is disabled by default. To enable OpenMP, the following tutorial can be followed <a href="https://mac.r-project.org/openmp/">https://mac.r-project.org/openmp/</a>. We created a separate branch for installation of <em>MeDeCom</em>
+on Windows machines. However, parallel processing options are currently
  not supported for Windows due to some incompatabilites of the R/Windows
  connection. Thus, executing MeDeCom on a Windows machine takes 
 sustantially longer. Additionally, we creared a Docker image with 

--- a/vignettes/MeDeCom.md
+++ b/vignettes/MeDeCom.md
@@ -50,6 +50,7 @@ devtools::install_github("lutsik/MeDeCom")
 ```
 
 The master branch of the GitHub repository only compiles on *nix-like* platforms with a C++11-compatible compiler are supported.
+Users on Mac OS might run into compilation errors as OpenMP, which is required for compilation, is disabled by default. To enable OpenMP, the following tutorial can be followed [https://mac.r-project.org/openmp/](https://mac.r-project.org/openmp/)
 We created a separate branch for installation of *MeDeCom* on Windows machines. However, parallel processing options are currently
 not supported for Windows due to some incompatabilites of the R/Windows connection. Thus, executing MeDeCom on a Windows machine
 takes sustantially longer. Additionally, we creared a Docker image with MeDeCom, which can be used in case of further installation


### PR DESCRIPTION
Hi, I've added a line linking to the tutorial that fixes the Mac compilation error to the vignette